### PR TITLE
Änderung auf Wunsch von Freigraf im IRC #ffruhr

### DIFF
--- a/communities/communities.json
+++ b/communities/communities.json
@@ -393,7 +393,7 @@
     "map": "http://map.freifunk-ruhrgebiet.de/HA/",
     "prefix": "/^FF-HA-/i",
     "Domaene": "EN-Kreis",
-    "Firmware": "http://firmware.freifunk-en.de/images/hagen/",
+    "Firmware": "http://images.freifunk-ruhrgebiet.de/stable/",
     "contacts": [
       {
         "firstname": "Team Hagen",


### PR DESCRIPTION
(Freigraf) Ist gerade jmnd da, der freifunk-ruhrgebiet/kontakt und dort speziell die Firmware Downloads verwaltet?
(chrisno) die links füren auf verschiedene Server, für welchen kontakt meinst du denn ?
(ReVoLt112) Wollt grad sagen, woher kommst du denn? =)
(Freigraf) Dort wird eine falsche Firmware verlinkt. Mailadresse und Webseite sind korrekt.
(ReVoLt112) Welche?
(Freigraf) Hagen.
(ReVoLt112) Warum falsch?
(ReVoLt112) http://firmware.freifunk-en.de/images/hagen/ ?
(ReVoLt112) Vom Prinzip her, wenn du ein Github Account hast, kannst du die einträge selber pflegen
(Freigraf) Das ist diese Sache mit dem Prinzip.
(ReVoLt112) Wo muss der link denn hin?
(Freigraf) Es gibt da eine FF API, dort hatte ich alles eingepflegt. Wird nicht genutzt, sondern wieder was neues gebaut. Menno...
(chrisno) Lars ?
(Freigraf) Vorerst zurück auf die originale Ruhrgebiets-Firmware http://images.freifunk-ruhrgebiet.de/stable/
(ReVoLt112) Warum wenn ich fragen darf?
(ReVoLt112) Bevor ich jetzt nen Pullrequest mache und wieder auf RG verweise und nachher ärger bekomme =)
(Freigraf) Die Firmware, auf die jetzt verwiesen wird, hat uns der Mattes zum Spielen gebaut. Das ist eine interne Version, die nicht zur Veröffentlichung gedacht war.
(Freigraf) Auf allen Routern in HA läuft Stand heute komplett zu 100% die RG Firmware.
(Freigraf) Siehe http://map.freifunk-ruhrgebiet.de/alfred/alfred.html   dort bei FF-HA-*
(ReVoLt112) Domäne ist dann wieder Ruhrgebiet oder lassen auf EN-Kreis?
(Freigraf) Derzeit noch RG. Der Unstieg zum EN-Kreis ist nocht nicht final.
